### PR TITLE
Initialize $arr_classes to avoid TypeError

### DIFF
--- a/src/WordPressMenuClasses.php
+++ b/src/WordPressMenuClasses.php
@@ -82,6 +82,7 @@ class WordPressMenuClasses
     public function navMenuCSSClass($classes, $item, $args, $depth)
     {
         $index = $item->menu_order;
+        $arr_classes = [];
 
         if (property_exists($args, 'li_class')) {
             $arr_classes = explode(' ', $args->li_class);


### PR DESCRIPTION
Hi, thanks a lot for the project.

While testing it, I noticed that if we just call the menu like that:
```
wp_nav_menu([
    'theme_location' => 'menu-1',
]);
```

we get:
`NOTICE: PHP message: PHP Warning:  Undefined variable $arr_classes in /var/www/html/wp-content/themes/mad/theme/inc/menuclasses.php on line 95
NOTICE: PHP message: PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #2 must be of type array, null given in /var/www/html/wp-content/themes/mad/theme/inc/menuclasses.php:95`

Initializing $arr_classes to an empty array solves it.